### PR TITLE
Fix blog popup layout

### DIFF
--- a/frontend/src/components/BlogPopup.jsx
+++ b/frontend/src/components/BlogPopup.jsx
@@ -3,18 +3,22 @@ import React from 'react';
 const BlogPopup = ({ post, onClose }) => {
   if (!post) return null;
 
+  const handleContainerClick = (e) => {
+    if (e.target.classList.contains('pop-up-info-articulo')) onClose();
+  };
+
   return (
-    <section className="pop-up-info-articulo" style={{ display: 'flex' }}>
-      <div className="pop-up-info-articulo-inner">
-        <img src={`./img/${post.imagen_url}`} alt="Post Image" />
+    <div className="pop-up-info-articulo" onClick={handleContainerClick}>
+      <div className="pop-up-info-articulo-inner" onClick={(e) => e.stopPropagation()}>
+        <img src="./img/icon_close.svg" className="close-btn" onClick={onClose} alt="Cerrar" />
+        <img src={`./img/${post.imagen_url}`} alt="Imagen del post" />
         <h1>{post.titulo_post}</h1>
         <h3>Escrito por todo el equipo de Zeta</h3>
         <hr />
         <span>{post.fecha_creacion}</span>
         <p>{post.contenido_post}</p>
-        <button className="btn-login" onClick={onClose} style={{ marginTop: '1rem' }}>Cerrar</button>
       </div>
-    </section>
+    </div>
   );
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -856,25 +856,38 @@ gap: .5rem;
 }
 
 .pop-up-info-articulo {
-  padding-top: 2rem;
-  padding-bottom: 5rem;
-  display: none;
-  width: 100%;
-  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
   justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  z-index: 1000;
+  overflow-y: auto;
 }
 
 .pop-up-info-articulo-inner {
   width: 100%;
-  
+  max-width: 700px;
+  background-color: var(--whiteback-color);
+  border-radius: 10px;
+  padding: 2rem;
   display: flex;
   flex-direction: column;
-  align-items: start;
-  gap: 2rem;
+  align-items: flex-start;
+  gap: 1.5rem;
+  position: relative;
 }
 
 .pop-up-info-articulo-inner img {
   width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 8px;
 }
 
 .pop-up-info-articulo-inner hr {


### PR DESCRIPTION
## Summary
- make BlogPopup overlay fullscreen and centered
- refine popup styles for better UX

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c0b0e8e748331847431db00d714d0