### PR TITLE
Fix blog popup and dynamic blog posts

### DIFF
--- a/backend/routes/home.routes.js
+++ b/backend/routes/home.routes.js
@@ -9,6 +9,7 @@ const controller = require('../controllers/home.controller');
 router.get('/', controller.index);
 router.get('/product', controller.product);
 router.get('/SearchProducts', controller.searchProducts);
+router.get('/blog', controller.blog);
 router.post('/darLike', controller.darLike);
 router.post('/darDislike', controller.darDislike);
 router.post('/publicarPost', controller.publicarPost);

--- a/frontend/src/Pages/BlogPage.jsx
+++ b/frontend/src/Pages/BlogPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import BlogCard from '../components/BlogCard';
 import BlogPopup from '../components/BlogPopup';
 
@@ -8,41 +9,15 @@ const BlogPage = () => {
   const [search, setSearch] = useState('');
 
   useEffect(() => {
-    // fetch('/api/blogposts') // <-- acá conectás con el backend
-    //   .then(res => res.json())
-    //   .then(data => setPosts(data));
-
-    // TEMP: Posts simulados
-    setPosts([
-      {
-        titulo_post: 'Alimentación intuitiva',
-        contenido_post:
-          'Escuchá a tu cuerpo y aprendé a reconocer las señales internas de hambre y saciedad. Esta práctica busca reconectar con tus necesidades reales, dejando de lado las dietas restrictivas.',
-        imagen_url: 'imgBlog1.jpg',
-        fecha_creacion: '2024-04-01'
-      },
-      {
-        titulo_post: 'Hábitos sostenibles',
-        contenido_post:
-          'Cómo comer mejor sin complicarte la vida: pequeñas acciones diarias pueden generar grandes cambios en tu salud y en el planeta. Empezá por lo simple.',
-        imagen_url: 'imgBlog1.jpg',
-        fecha_creacion: '2024-03-28'
-      },
-      {
-        titulo_post: 'Mindful eating: comer con atención',
-        contenido_post:
-          'Aprendé a disfrutar cada bocado, prestando atención al momento presente. Esta técnica mejora la relación con la comida y reduce los atracones.',
-        imagen_url: 'imgBlog1.jpg',
-        fecha_creacion: '2024-03-15'
-      },
-      {
-        titulo_post: 'Organización semanal de comidas',
-        contenido_post:
-          'Planificar tus comidas no solo te ahorra tiempo, también mejora tu nutrición. Te mostramos cómo hacerlo de forma práctica y flexible.',
-        imagen_url: 'imgBlog1.jpg',
-        fecha_creacion: '2024-03-05'
+    const fetchPosts = async () => {
+      try {
+        const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/api/blog`);
+        setPosts(data);
+      } catch (err) {
+        console.error('Error al obtener posts del blog:', err);
       }
-    ]);
+    };
+    fetchPosts();
   }, []);
 
   const handleSearch = (e) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -865,22 +865,24 @@ gap: .5rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 2rem;
+  padding: 0;
   z-index: 1000;
   overflow-y: auto;
 }
 
 .pop-up-info-articulo-inner {
   width: 100%;
-  max-width: 700px;
+  height: 100%;
+  max-width: none;
   background-color: var(--whiteback-color);
-  border-radius: 10px;
+  border-radius: 0;
   padding: 2rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 1.5rem;
   position: relative;
+  overflow-y: auto;
 }
 
 .pop-up-info-articulo-inner img {


### PR DESCRIPTION
## Summary
- add missing `/blog` route in the backend
- fetch real blog posts on the Blog page
- make the blog post popup take the whole viewport

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c0caa22a88331831ac1bb200eb0ee