### PR TITLE
Integrate Clerk for authentication

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 #VITE_API_URL=https://zeta-v2.onrender.com
 VITE_API_URL=http://localhost:3000
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_REPLACE_ME

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@clerk/clerk-react": "^5.31.9",
         "axios": "^1.8.4",
         "my-app": "file:..",
         "react": "^19.0.0",
@@ -331,6 +332,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.31.9",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.31.9.tgz",
+      "integrity": "sha512-jP+qygYcChVDKM3pMtChOGNrGV4QAOYQvVyiitzQu5xgyVsFN3AnSdIj0u73lxOLZubfv9cOHjFwc41s31f1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.9.6",
+        "@clerk/types": "^4.60.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.9.6.tgz",
+      "integrity": "sha512-zScvDbNKBcGfkD7Db4LCoEbB8qZ/WFwuB77xqRgXiHDa+pBzEPyFB5nQSt1zQfLqOK3POng0GsPBoXEWKb4Ikw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.60.0",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.60.0.tgz",
+      "integrity": "sha512-60u/Z3VD0lgepsySUPyFM1MV5cwhMwouN63na5g9+qm3PpaTE2kN4DeW9Nq6t1YB0TFpVEKIb1r8U6EOWPa01A==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1692,7 +1753,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1727,6 +1787,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dunder-proto": {
@@ -2228,6 +2297,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
@@ -2368,6 +2443,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2901,6 +2985,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2926,6 +3016,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
@@ -2985,6 +3094,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@clerk/clerk-react": "^5.31.9",
     "axios": "^1.8.4",
     "my-app": "file:..",
     "react": "^19.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import BlogPage from './Pages/BlogPage';
 import CommunityPage from './Pages/CommunityPage';
 import ProductPage from './Pages/ProductPage';
 import LoginPage from './Pages/Login';
+import SignUpPage from './Pages/SignUp';
 import SearchResults from './Pages/SearchResults'; 
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
         <Route path="/community" element={<CommunityPage />} />
         <Route path="/producto" element={<ProductPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/sign-up" element={<SignUpPage />} />
         <Route path="/search" element={<SearchResults />} />
       </Routes>
     </Layout>

--- a/frontend/src/Pages/Login.jsx
+++ b/frontend/src/Pages/Login.jsx
@@ -1,35 +1,5 @@
-import { useState } from 'react';
 import LoginSection from '../components/LoginSection';
-import Ca1Section from '../components/Ca1Section';
-import Ca2Section from '../components/Ca2Section';
-// import Ca3Section from '../components/Ca3Section';
 
 export default function Login() {
-  const [step, setStep] = useState('login');
-
-  const [formData, setFormData] = useState({
-    email: '',
-    password: '',
-    nombre: '',
-    apellido: '',
-    fecha_nacimiento: '',
-    genero: '',
-    altura: '',
-    peso: '',
-  });
-
-  const updateForm = (data) => {
-    setFormData(prev => ({ ...prev, ...data }));
-  };
-
-  return (
-    <>
-      {step === 'login' && <LoginSection goTo={setStep} />}
-      {step === 'ca1' && <Ca1Section goTo={setStep} updateForm={updateForm} />}
-      {step === 'ca2' && <Ca2Section goTo={setStep} updateForm={updateForm} formData={formData} />}
-
-
-      {/* {step === 'ca3' && <Ca3Section goTo={setStep} formData={formData} />} */}
-    </>
-  );
+  return <LoginSection />;
 }

--- a/frontend/src/Pages/SignUp.jsx
+++ b/frontend/src/Pages/SignUp.jsx
@@ -1,8 +1,9 @@
-import { SignIn } from '@clerk/clerk-react';
+import { SignUp } from '@clerk/clerk-react';
+import LoginSection from '../components/LoginSection';
 
-export default function LoginSection() {
+export default function SignUpPage() {
   return (
-    <section id="login-section" className="login-container">
+    <section id="signup-section" className="login-container">
       <div className="login-content">
         <button className="back-button" onClick={() => window.location.href = '/'}>
           <img src="/img/icon_back.svg" alt="Back" />
@@ -11,7 +12,7 @@ export default function LoginSection() {
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>
         <div className="welcome-message">
-          <SignIn path="/login" routing="path" signUpUrl="/sign-up" afterSignInUrl="/" />
+          <SignUp path="/sign-up" routing="path" signInUrl="/login" afterSignUpUrl="/" />
         </div>
       </div>
     </section>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ClerkProvider } from '@clerk/clerk-react';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-
+  <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-
+  </ClerkProvider>
 );


### PR DESCRIPTION
## Summary
- add Clerk dependency and publishable key env var
- wrap app with `ClerkProvider`
- refactor login page to use Clerk `SignIn` component
- add sign up page using Clerk `SignUp`
- route `/sign-up` in router

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c1c85af9083318f38b718fd276792