### PR TITLE
Fix Clerk publishable key

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,4 @@
 #VITE_API_URL=https://zeta-v2.onrender.com
 VITE_API_URL=http://localhost:3000
-VITE_CLERK_PUBLISHABLE_KEY=sk_test_5SW9Xtr1JuQmoLOwkjccJvUpPWzti6cqNMRNg3sfZD
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3VudHMuZGV2JA
+


### PR DESCRIPTION
## Summary
- restore proper Clerk publishable key in frontend/.env

## Testing
- `npm run dev --prefix frontend` *(fails: npm warns but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684c29f5676883319313e93871090e9b