### PR TITLE
Fix Clerk session configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ yarn-error.log*
 
 # Build
 build
+.env
+backend/.env

--- a/README.md
+++ b/README.md
@@ -181,4 +181,5 @@ El frontend utiliza [Clerk](https://clerk.com/) para el inicio de sesión. Al in
 se sincroniza automáticamente con nuestro backend y la base de datos en Supabase.
 
 1. Configurá la clave `VITE_CLERK_PUBLISHABLE_KEY` en `frontend/.env`.
-2. Iniciá la app con `npm run dev` y Clerk manejará las sesiones.
+2. En `backend/.env` agregá tu `CLERK_SECRET_KEY` para que el servidor pueda verificar los tokens de sesión.
+3. Iniciá la app con `npm run dev` y Clerk manejará las sesiones.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+CLERK_SECRET_KEY=sk_test_your_secret_key_here
+PORT=3000

--- a/backend/app.js
+++ b/backend/app.js
@@ -28,11 +28,11 @@ app.use(session({
   secret: 'zeta_secret',
   resave: false,
   saveUninitialized: false,
-  // cookie: {
-  //   secure: false, // true si usás HTTPS
-  //   httpOnly: true,
-  //   sameSite: 'lax'
-  // }
+  cookie: {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+  }
 }));
 
 // 📦 Rutas

--- a/backend/controllers/home.controller.js
+++ b/backend/controllers/home.controller.js
@@ -64,12 +64,13 @@ const homeController = {
   // 🔐 Sincronizar sesión con Clerk
   clerkSync: async (req, res) => {
     try {
-      const { verifySessionToken } = require('@clerk/clerk-sdk-node');
+      const { clerkClient } = require('@clerk/clerk-sdk-node');
       const token = req.body.token || req.headers.authorization?.replace('Bearer ', '');
       if (!token) return res.status(400).json({ error: 'Token requerido' });
 
-      const session = await verifySessionToken(token);
-      const email = session?.session?.user?.email_addresses?.[0]?.email_address;
+      const payload = await clerkClient.base.verifySessionToken(token);
+      const userData = await clerkClient.users.getUser(payload.sub);
+      const email = userData.email_addresses?.[0]?.email_address;
 
       if (!email) throw new Error('No se pudo obtener email');
 
@@ -78,7 +79,7 @@ const homeController = {
       if (!usuario) {
         usuario = await prisma.usuarios.create({
           data: {
-            nombre: session.session.user.first_name || 'Usuario',
+            nombre: userData.firstName || 'Usuario',
             email,
             fecha_registro: new Date(),
           }


### PR DESCRIPTION
## Summary
- enable secure cookie options for express-session
- provide example `.env` for backend with `CLERK_SECRET_KEY`
- ignore backend `.env` files in git
- document that the server requires `CLERK_SECRET_KEY`
- verify Clerk tokens using `clerkClient`

## Testing
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853f513931c83319c7b2a5c32b1790b