### PR TITLE
Organize environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,9 @@ yarn-error.log*
 # Build
 build
 
-# backend/.env
+# Sensitive environment variables
 backend/.env.secrets
+backend/.env.local
 
 
 backend/camera-service/credentials/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Zeta-v2
+
+## Environment configuration
+
+The project uses two environment files inside the `backend` folder:
+
+- `.env` contains public configuration and **is committed** to the repository.
+- `.env.secrets` holds sensitive keys like database credentials, the OpenAI API key and the Google Vision credentials path. This file is ignored by Git. Use `.env.secrets.example` as a template.
+
+The frontend keeps its own public variables in `frontend/.env`.

--- a/backend/.env
+++ b/backend/.env
@@ -1,10 +1,8 @@
 # Connect to Supabase via connection pooling
-DATABASE_URL="postgresql://postgres.cuphajddgbzgnomwsupa:Rvwepe2t2010@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true"
 PORT=3000
 OPENFOODFACTS_PRODUCT_URL=https://world.openfoodfacts.org/api/v0/product
 OPENFOODFACTS_SEARCH_URL=https://world.openfoodfacts.org/cgi/search.pl
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3VudHMuZGV2JA
-CLERK_SECRET_KEY=sk_test_5SW9Xtr1JuQmoLOwkjccJvUpPWzti6cqNMRNg3sfZD
 VITE_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
 OPENFOODFACTS_API_URL=https://world.openfoodfacts.org/cgi/search.pl

--- a/backend/.env.secrets.example
+++ b/backend/.env.secrets.example
@@ -1,0 +1,5 @@
+# Sensitive credentials for the backend
+DATABASE_URL=
+CLERK_SECRET_KEY=
+OPENAI_API_KEY=
+GOOGLE_APPLICATION_CREDENTIALS=./camera-service/credentials/google-vision.json

--- a/backend/app.js
+++ b/backend/app.js
@@ -7,7 +7,6 @@ const cameraRoutes = require('./routes/camera.routes');
 
 // Cargar variables de entorno
 dotenv.config({ path: '.env' });
-dotenv.config({ path: '.env.local', override: true });
 dotenv.config({ path: '.env.secrets', override: true });
 
 const allowedOrigins = [

--- a/backend/camera-service/index.js
+++ b/backend/camera-service/index.js
@@ -5,7 +5,6 @@ const path = require('path');
 const dotenv = require('dotenv');
 // Cargar variables de entorno para el servicio de cámara
 dotenv.config({ path: path.join(__dirname, '..', '.env') });
-dotenv.config({ path: path.join(__dirname, '..', '.env.local'), override: true });
 dotenv.config({ path: path.join(__dirname, '..', '.env.secrets'), override: true });
 
 const express = require('express');
@@ -18,7 +17,9 @@ const app = express();
 app.use(cors());
 
 // Ruta a credenciales de Google Vision
-process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, 'credentials', 'google-vision.json');
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, 'credentials', 'google-vision.json');
+}
 
 const OFF_PROD_URL = process.env.OPENFOODFACTS_PRODUCT_URL;
 const OFF_SEARCH_URL = process.env.OPENFOODFACTS_SEARCH_URL;

--- a/backend/controllers/camera.controller.js
+++ b/backend/controllers/camera.controller.js
@@ -5,7 +5,15 @@ const vision = require('@google-cloud/vision');
 const OFF_PROD_URL = process.env.OPENFOODFACTS_PRODUCT_URL;
 const OFF_SEARCH_URL = process.env.OPENFOODFACTS_SEARCH_URL;
 
-process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, '..', 'camera-service', 'credentials', 'google-vision.json');
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(
+    __dirname,
+    '..',
+    'camera-service',
+    'credentials',
+    'google-vision.json'
+  );
+}
 
 const visionClient = new vision.ImageAnnotatorClient();
 


### PR DESCRIPTION
## Summary
- keep public environment variables in `backend/.env`
- move sensitive variables to `.env.secrets` and ignore the file
- update backend code to load `.env` and `.env.secrets`
- let Google Vision credentials path come from the env
- add an example `.env.secrets` template
- document the setup in `README.md`

## Testing
- `npm -v`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68586c26494c8331838e67e7ae93d810