### PR TITLE
Enable webcam capture for product search

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@clerk/clerk-react": "^5.31.9",
     "axios": "^1.8.4",
+    "react-webcam": "^7.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.0"

--- a/frontend/src/components/CameraModal.jsx
+++ b/frontend/src/components/CameraModal.jsx
@@ -1,0 +1,42 @@
+import React, { useRef } from 'react';
+import Webcam from 'react-webcam';
+
+const CameraModal = ({ isOpen, onClose, onCapture }) => {
+  const webcamRef = useRef(null);
+
+  if (!isOpen) return null;
+
+  const capture = async () => {
+    if (webcamRef.current) {
+      const imageSrc = webcamRef.current.getScreenshot();
+      if (imageSrc) {
+        const res = await fetch(imageSrc);
+        const blob = await res.blob();
+        onCapture(blob);
+      }
+    }
+  };
+
+  const handleContainerClick = (e) => {
+    if (e.target.classList.contains('popup-container')) onClose();
+  };
+
+  return (
+    <div className="popup-container" onClick={handleContainerClick}>
+      <div className="popup-content" onClick={e => e.stopPropagation()}>
+        <img src="./img/icon_close.svg" className="close-btn" onClick={onClose} alt="Cerrar" />
+        <div className="camera-wrapper">
+          <Webcam
+            audio={false}
+            ref={webcamRef}
+            screenshotFormat="image/jpeg"
+            videoConstraints={{ facingMode: 'environment' }}
+          />
+        </div>
+        <button className="capture-btn" onClick={capture}>Tomar foto</button>
+      </div>
+    </div>
+  );
+};
+
+export default CameraModal;

--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -1,9 +1,11 @@
 // src/components/HeroSection.jsx
 import React, { useState, useRef } from 'react';
+import CameraModal from './CameraModal';
 import { useNavigate } from 'react-router-dom';
 
 const HeroSection = () => {
   const [query, setQuery] = useState('');
+  const [showCamera, setShowCamera] = useState(false);
   const navigate = useNavigate();
   const fileInputRef = useRef(null);
 
@@ -14,14 +16,19 @@ const HeroSection = () => {
   };
 
   const handleCameraClick = () => {
-    fileInputRef.current?.click();
+    setShowCamera(true);
   };
 
-  const handleCapture = async (e) => {
-    const file = e.target.files[0];
+  const handleCapture = async (source) => {
+    let file = null;
+    if (source && source.target) {
+      file = source.target.files[0];
+    } else if (source instanceof Blob) {
+      file = source;
+    }
     if (!file) return;
     const formData = new FormData();
-    formData.append('image', file);
+    formData.append('image', file, 'capture.jpg');
     try {
       const res = await fetch('http://localhost:3000/api/camera/upload', {
         method: 'POST',
@@ -34,6 +41,8 @@ const HeroSection = () => {
       }
     } catch (err) {
       console.error('Camera search error', err);
+    } finally {
+      setShowCamera(false);
     }
   };
 
@@ -80,6 +89,11 @@ const HeroSection = () => {
                 ref={fileInputRef}
                 style={{ display: 'none' }}
                 onChange={handleCapture}
+              />
+              <CameraModal
+                isOpen={showCamera}
+                onClose={() => setShowCamera(false)}
+                onCapture={handleCapture}
               />
             </div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,3 +16,4 @@
 @import './styles/contact-page.css';
 @import './styles/nutrition-evaluation-section.css';
 @import './styles/search-results.css';
+@import './styles/camera.css';

--- a/frontend/src/styles/camera.css
+++ b/frontend/src/styles/camera.css
@@ -1,0 +1,14 @@
+.camera-wrapper video {
+  width: 100%;
+  border-radius: 10px;
+}
+
+.capture-btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: var(--primary-color);
+  color: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.5.0"
+        "react-router-dom": "^7.5.0",
+        "react-webcam": "^7.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -5095,6 +5096,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-webcam": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-webcam/-/react-webcam-7.2.0.tgz",
+      "integrity": "sha512-xkrzYPqa1ag2DP+2Q/kLKBmCIfEx49bVdgCCCcZf88oF+0NPEbkwYk3/s/C7Zy0mhM8k+hpdNkBLzxg8H0aWcg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-dom": ">=16.2.0"
       }
     },
     "node_modules/readable-stream": {


### PR DESCRIPTION
## Summary
- add a CameraModal component that uses `react-webcam`
- add webcam styles and import them
- update HeroSection to open the webcam modal and send captured image
- install `react-webcam`

## Testing
- `npm install --workspace frontend`
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68589b46d52c83319b9123fb48a2a6f0