### PR TITLE
Add loaders for improved UX

### DIFF
--- a/frontend/src/components/CameraModal.jsx
+++ b/frontend/src/components/CameraModal.jsx
@@ -1,9 +1,11 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import Webcam from 'react-webcam';
 import { FaTimes } from 'react-icons/fa';
+import Loader from './Loader';
 
 const CameraModal = ({ isOpen, onClose, onCapture }) => {
   const webcamRef = useRef(null);
+  const [capturing, setCapturing] = useState(false);
 
   if (!isOpen) return null;
 
@@ -11,9 +13,11 @@ const CameraModal = ({ isOpen, onClose, onCapture }) => {
     if (webcamRef.current) {
       const imageSrc = webcamRef.current.getScreenshot();
       if (imageSrc) {
+        setCapturing(true);
         const res = await fetch(imageSrc);
         const blob = await res.blob();
-        onCapture(blob);
+        await onCapture(blob);
+        setCapturing(false);
       }
     }
   };
@@ -37,6 +41,11 @@ const CameraModal = ({ isOpen, onClose, onCapture }) => {
           />
         </div>
         <button className="capture-btn" onClick={capture}>Tomar foto</button>
+        {capturing && (
+          <div className="capture-loader">
+            <Loader />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/CommunityPosts.jsx
+++ b/frontend/src/components/CommunityPosts.jsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from 'react';
+import Loader from './Loader';
 
 const CommunityPosts = () => {
   const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+     setLoading(true);
      fetch("/api/posts/last3")  // ← Ejemplo de conexión
       .then(res => res.json())
-       .then(data => setPosts(data));
+       .then(data => setPosts(data))
+       .finally(() => setLoading(false));
   }, []);
 
   return (
@@ -14,18 +18,22 @@ const CommunityPosts = () => {
       <div className="advertisements-blog-inner">
         <h2>Últimos Posts de nuestra comunidad</h2>
         <div className="cards-container">
-          {posts.map((post, i) => (
-            <div className="card-advertisement-blog" key={i}>
-              <div className="arriba-card-blog">
-                <p className="fecha-card-blog">{/* post.fecha_creacion */}</p>
-                <h3 className="titulo-card-blog">{post.titulo_post}</h3>
-                <p className="descripcion-card-blog">{post.contenido_post}</p>
+          {loading ? (
+            <Loader />
+          ) : (
+            posts.map((post, i) => (
+              <div className="card-advertisement-blog" key={i}>
+                <div className="arriba-card-blog">
+                  <p className="fecha-card-blog">{/* post.fecha_creacion */}</p>
+                  <h3 className="titulo-card-blog">{post.titulo_post}</h3>
+                  <p className="descripcion-card-blog">{post.contenido_post}</p>
+                </div>
+                <div className="contenedor-imagen-card-blog">
+                  <img src={`./img/${post.imagen_url}`} alt="Imagen del post" />
+                </div>
               </div>
-              <div className="contenedor-imagen-card-blog">
-                <img src={`./img/${post.imagen_url}`} alt="Imagen del post" />
-              </div>
-            </div>
-          ))}
+            ))
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useAuth } from '@clerk/clerk-react';
+import Loader from './Loader';
 import {
   FaHome,
   FaUsers,
@@ -12,13 +13,14 @@ import {
 } from 'react-icons/fa';
 
 const Header = () => {
-  const { isSignedIn, getToken, signOut } = useAuth();
+  const { isLoaded, isSignedIn, getToken, signOut } = useAuth();
   const [auth, setAuth] = useState({ authenticated: false, user: null });
   const [loading, setLoading] = useState(true); // nuevo estado
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const navigate = useNavigate();
   
   useEffect(() => {
+    if (!isLoaded) return;
     const syncSession = async () => {
       try {
         if (isSignedIn) {
@@ -75,9 +77,9 @@ const Header = () => {
       hamburgerBtn?.removeEventListener('click', toggleMenu);
       window.removeEventListener('resize', closeMenuOnResize);
     };
-  }, [isSignedIn]);
+  }, [isLoaded, isSignedIn]);
 
-  if (loading) return null; 
+  if (!isLoaded || loading) return <Loader />;
 
   const handleLogout = async () => {
     await signOut();

--- a/frontend/src/components/Loader.jsx
+++ b/frontend/src/components/Loader.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Loader = () => (
+  <div className="loader">
+    <img src="/img/loader.gif" alt="Cargando..." />
+  </div>
+);
+
+export default Loader;

--- a/frontend/src/pages/BlogPage.jsx
+++ b/frontend/src/pages/BlogPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Loader from '../components/Loader';
 import axios from 'axios';
 import BlogCard from '../components/BlogCard';
 import BlogPopup from '../components/BlogPopup';
@@ -8,14 +9,18 @@ const BlogPage = () => {
   const [posts, setPosts] = useState([]);
   const [popupPost, setPopupPost] = useState(null);
   const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchPosts = async () => {
+      setLoading(true);
       try {
         const { data } = await axios.get(`${import.meta.env.VITE_API_URL}/api/blog`);
         setPosts(data);
       } catch (err) {
         console.error('Error al obtener posts del blog:', err);
+      } finally {
+        setLoading(false);
       }
     };
     fetchPosts();
@@ -71,9 +76,13 @@ const BlogPage = () => {
             Explorá artículos cuidadosamente seleccionados sobre bienestar integral, alimentación consciente y hábitos saludables. Inspirate para hacer cambios positivos y sostenibles.
           </p>
           <div className="cards-row" id="cardsContainer">
-            {posts.map((post, idx) => (
-              <BlogCard key={idx} post={post} onClick={handleCardClick} />
-            ))}
+            {loading ? (
+              <Loader />
+            ) : (
+              posts.map((post, idx) => (
+                <BlogCard key={idx} post={post} onClick={handleCardClick} />
+              ))
+            )}
           </div>
         </div>
       </section>

--- a/frontend/src/pages/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Loader from '../components/Loader';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import CommunityCard from '../components/CommunityCard';
@@ -10,9 +11,11 @@ const CommunityPage = () => {
   const [popupOpen, setPopupOpen] = useState(false);
   const [newPostContent, setNewPostContent] = useState('');
   const [auth, setAuth] = useState({ authenticated: false });
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
   const fetchPosts = async () => {
+    setLoading(true);
     try {
       const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/obtenerPosts`, {withCredentials: true});
       if (response.data.success) {
@@ -30,6 +33,8 @@ const CommunityPage = () => {
       }
     } catch (error) {
       console.error('Error al obtener posts:', error);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -96,7 +101,9 @@ const CommunityPage = () => {
         <div className="inner-community">
           <h1 className="community-title">Comunidad</h1>
           <div className="community-cards-container">
-            {posts.length === 0 ? (
+            {loading ? (
+              <Loader />
+            ) : posts.length === 0 ? (
               <p>No hay posts aún. ¡Sé el primero en publicar!</p>
             ) : (
               posts.map(post => (

--- a/frontend/src/pages/ProductPage.jsx
+++ b/frontend/src/pages/ProductPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Loader from '../components/Loader';
 import { useSearchParams } from 'react-router-dom';
 import { FaCheck, FaTimes, FaMinus } from 'react-icons/fa';
 
@@ -175,7 +176,7 @@ const ProductPage = () => {
           </div>
         </>
       ) : (
-        <p>Cargando...</p>
+        <Loader />
       )}
     </div>
   );

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -116,3 +116,11 @@ main {
 
 
 
+
+/* Global loader style */
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}

--- a/frontend/src/styles/camera.css
+++ b/frontend/src/styles/camera.css
@@ -12,3 +12,15 @@
   border-radius: 8px;
   cursor: pointer;
 }
+
+.capture-loader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.7);
+}


### PR DESCRIPTION
## Summary
- add reusable Loader component and styles
- update Header to display loader while syncing auth
- show loading indicator on community & blog pages
- show loader while capturing photo and overlay style for camera modal
- replace text loading message with Loader component in product page
- display loaders for last community posts

## Testing
- `npm run lint --workspace frontend` *(fails: 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_6859773416d4833186f6f77aea413752