### PR TITLE
Improve profile dropdown

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
+import { ProfilePopupProvider } from './context/ProfilePopupContext';
 import HomePage from './pages/HomePage';
 import BlogPage from './pages/BlogPage';
 import CommunityPage from './pages/CommunityPage';
@@ -11,8 +12,9 @@ import ContactPage from './pages/ContactPage';
 
 function App() {
   return (
-    <Layout>
-      <Routes>
+    <ProfilePopupProvider>
+      <Layout>
+        <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/blog" element={<BlogPage />} />
         <Route path="/community" element={<CommunityPage />} />
@@ -22,7 +24,8 @@ function App() {
         <Route path="/search" element={<SearchResults />} />
         <Route path="/contact" element={<ContactPage />} />
       </Routes>
-    </Layout>
+      </Layout>
+    </ProfilePopupProvider>
   );
 }
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import Header from './Header';
 import Footer from './Footer';
+import ProfilePopup from './ProfilePopup';
+import { useProfilePopup } from '../context/ProfilePopupContext';
 
 const Layout = ({ children }) => {
+  const { isProfileOpen, closeProfile } = useProfilePopup();
   return (
     <>
       <Header />
       <main>{children}</main>
       <Footer />
+      <ProfilePopup
+        isOpen={isProfileOpen}
+        onClose={closeProfile}
+        onSaved={closeProfile}
+      />
     </>
   );
 };

--- a/frontend/src/context/ProfilePopupContext.js
+++ b/frontend/src/context/ProfilePopupContext.js
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ProfilePopupContext = createContext();
+
+export const useProfilePopup = () => useContext(ProfilePopupContext);
+
+export const ProfilePopupProvider = ({ children }) => {
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+
+  const openProfile = () => setIsProfileOpen(true);
+  const closeProfile = () => setIsProfileOpen(false);
+
+  return (
+    <ProfilePopupContext.Provider value={{ isProfileOpen, openProfile, closeProfile }}>
+      {children}
+    </ProfilePopupContext.Provider>
+  );
+};

--- a/frontend/src/styles/header.css
+++ b/frontend/src/styles/header.css
@@ -110,6 +110,32 @@ span.button-text{
   display: flex;
   flex-direction: column;
   z-index: 1000;
+  animation: fadeSlide 0.2s ease;
+}
+
+.profile-dropdown .dropdown-item {
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--secondary2-color);
+  font-family: var(--font-family-button);
+}
+
+.profile-dropdown .dropdown-item:hover {
+  background-color: var(--secondary5-color);
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ------------------ HAMBURGER MENU ------------------ */


### PR DESCRIPTION
## Summary
- add ProfilePopupContext and provider
- render ProfilePopup from Layout so any page can show it
- improve Header dropdown to open profile popup and close when clicking outside
- style dropdown items with a fade animation

## Testing
- `npm run lint --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_68597c0b7fa083319dea077b77316506