### PR TITLE
Improve product search UX

### DIFF
--- a/backend/controllers/home.controller.js
+++ b/backend/controllers/home.controller.js
@@ -313,13 +313,17 @@ registrarUsuario: async (req, res) => {
 
     try {
       const result = await axios.get(`https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&json=1`);
-      const productos = result.data.products.filter(p =>
-        ['es', 'en'].includes(p.lang) &&
-        (p.countries?.toLowerCase()?.includes('argentina') || true)
-      ).map(p => ({
-        name: p.product_name,
-        image: p.image_url || "/img/default_product.png"
-      }));
+      const productos = result.data.products
+        .filter(p =>
+          ['es', 'en'].includes(p.lang) &&
+          p.product_name &&
+          p.image_url &&
+          (p.countries?.toLowerCase()?.includes('argentina') || true)
+        )
+        .map(p => ({
+          name: p.product_name,
+          image: p.image_url
+        }));
 
       res.json({ success: true, products: productos });
     } catch (error) {

--- a/frontend/src/components/LazyImage.jsx
+++ b/frontend/src/components/LazyImage.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+
+const LazyImage = ({ src, alt, className }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className={`lazy-image-wrapper ${className || ''}`}>
+      {!loaded && <div className="image-skeleton" />}
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoaded(true)}
+        style={{ display: loaded ? 'block' : 'none' }}
+      />
+    </div>
+  );
+};
+
+export default LazyImage;

--- a/frontend/src/pages/SearchResults.jsx
+++ b/frontend/src/pages/SearchResults.jsx
@@ -1,5 +1,6 @@
 // src/pages/SearchResults.jsx
 import React, { useEffect, useState } from 'react';
+import LazyImage from '../components/LazyImage';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 
 const SearchResults = () => {
@@ -29,36 +30,43 @@ const SearchResults = () => {
     navigate(`/producto?query=${encodeURIComponent(name)}`);
   };
 
+  const skeletons = Array.from({ length: 6 });
+
   return (
     <div className="search-results-page">
       <header className="results-header">
         <h2>Resultados para &quot;{query}&quot;</h2>
       </header>
 
-      {loading
-        ? <div className="loader"><img src="/img/loader.gif" alt="Cargando..." /></div>
-        : products.length === 0
-          ? <p className="no-results">No se encontraron productos.</p>
-          : (
-            <div className="cards-container">
-              {products.map((p, i) => (
-                <div
-                  key={i}
-                  className="product-card"
-                  onClick={() => handleClick(p.name)}
-                >
-                  {p.image
-                    ? <img src={p.image} alt={p.name} className="card-image" />
-                    : <div className="card-placeholder">Sin imagen</div>
-                  }
-                  <h3 className="card-title">{p.name}</h3>
-                </div>
-              ))}
+      {loading ? (
+        <div className="cards-container">
+          {skeletons.map((_, i) => (
+            <div key={i} className="product-card">
+              <div className="lazy-image-wrapper">
+                <div className="image-skeleton" />
+              </div>
+              <h3 className="card-title">Cargando...</h3>
             </div>
-          )
-      }
+          ))}
+        </div>
+      ) : products.length === 0 ? (
+        <p className="no-results">No se encontraron productos.</p>
+      ) : (
+        <div className="cards-container">
+          {products.map((p, i) => (
+            <div
+              key={i}
+              className="product-card"
+              onClick={() => handleClick(p.name)}
+            >
+              <LazyImage src={p.image} alt={p.name} className="card-image" />
+              <h3 className="card-title">{p.name}</h3>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };
-
 export default SearchResults;
+

--- a/frontend/src/styles/search-results.css
+++ b/frontend/src/styles/search-results.css
@@ -56,6 +56,42 @@
   object-fit: cover;
 }
 
+/* Lazy image wrapper to handle skeleton */
+.search-results-page .lazy-image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+}
+
+.search-results-page .lazy-image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.search-results-page .image-skeleton {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--secondary6-color);
+  animation: skeleton-loading 1.2s infinite ease-in-out;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
 /* Título dentro de la tarjeta */
 .search-results-page .product-card .card-title {
   padding: 1rem;


### PR DESCRIPTION
## Summary
- filter out products without title or image in searchProducts
- show skeletons while images load with new `LazyImage` component
- render card placeholders during result fetch
- style skeleton loader for product images

## Testing
- `npm run lint --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_68597e132c3c83319451358e038c2a4c