### PR TITLE
Improve icon spacing

### DIFF
--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -110,6 +110,17 @@ main {
   transition: transform 0.3s ease;
 }
 
+/* Support SVG icons for back button */
+.back-button svg {
+  width: 32px;
+  height: 32px;
+  transition: transform 0.3s ease;
+}
+
+.back-button svg:hover {
+  transform: scale(1.1);
+}
+
 .back-button img:hover {
   transform: scale(1.1);
 }

--- a/frontend/src/styles/blog.css
+++ b/frontend/src/styles/blog.css
@@ -135,3 +135,8 @@
   width: 40px;
   cursor: pointer;
 }
+
+.close-btn-popup svg {
+  width: 40px;
+  height: 40px;
+}

--- a/frontend/src/styles/community.css
+++ b/frontend/src/styles/community.css
@@ -93,6 +93,12 @@
   gap: .3rem;
 }
 
+/* Like/Dislike icons */
+.community-card-footer svg {
+  width: 20px;
+  height: 20px;
+}
+
 .button-add-post {
   position: fixed;
   bottom: 10vh;
@@ -206,6 +212,11 @@ textarea:focus, input:focus {
   cursor: pointer;
   top: 1.5rem;
   right: 2rem;
+}
+
+.close-btn svg {
+  width: 20px;
+  height: 20px;
 }
 
 /* Publish Button */

--- a/frontend/src/styles/header.css
+++ b/frontend/src/styles/header.css
@@ -37,6 +37,13 @@ header {
   width: 30px;
 }
 
+/* Ensure react-icon SVGs align with text like images */
+.nav-links a svg {
+  margin-right: 15px;
+  width: 30px;
+  height: 30px;
+}
+
 .login-button, .icon-group {
   display: flex;
   align-items: center;
@@ -91,6 +98,12 @@ span.button-text{
 .user-button img {
   height: 30px;
   width: 30px;
+}
+
+/* Normalize icon size inside the user menu */
+.user-button svg {
+  width: 24px;
+  height: 24px;
 }
 
 .user-button .arrow {

--- a/frontend/src/styles/hero.css
+++ b/frontend/src/styles/hero.css
@@ -95,6 +95,12 @@
   height: 33px;
 }
 
+/* Consistent sizing for icon components */
+.search-button svg {
+  width: 33px;
+  height: 33px;
+}
+
 .info-buttons {
   display: flex;
   justify-content: space-around;


### PR DESCRIPTION
## Summary
- refine icon positioning in header, hero search, community cards, and popups
- add support for SVG icons on back buttons

## Testing
- `npm run lint --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_6859886122948331aee9a150037265c1