### PR TITLE
Fix profile popup logic

### DIFF
--- a/frontend/src/components/ProfilePopup.jsx
+++ b/frontend/src/components/ProfilePopup.jsx
@@ -91,6 +91,7 @@ const ProfilePopup = ({ isOpen, onClose, onSaved }) => {
           <input type="number" name="frecuencia" placeholder="Horas semanales" value={form.frecuencia} onChange={handleChange} />
 
           <button type="submit" className="publish-btn">Guardar</button>
+          <button type="button" className="skip-btn" onClick={onClose}>Omitir</button>
         </form>
       </div>
     </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -6,12 +6,16 @@ import Functionalities from '../components/Functionalities';
 import CommunityPosts from '../components/CommunityPosts';
 import ContactSection from '../components/ContactSection';
 import ProfilePopup from '../components/ProfilePopup';
+import { useAuth } from '@clerk/clerk-react';
 import axios from 'axios';
 
 const HomePage = () => {
   const [showPopup, setShowPopup] = useState(false);
+  const { isLoaded, isSignedIn } = useAuth();
 
   useEffect(() => {
+    if (!isLoaded || !isSignedIn) return;
+
     const checkProfile = async () => {
       try {
         const auth = await axios.get(`${import.meta.env.VITE_API_URL}/api/auth`, { withCredentials: true });
@@ -22,8 +26,10 @@ const HomePage = () => {
         console.error('Error al verificar perfil', err);
       }
     };
-    checkProfile();
-  }, []);
+
+    const timer = setTimeout(checkProfile, 300);
+    return () => clearTimeout(timer);
+  }, [isLoaded, isSignedIn]);
 
   return (
     <div className="index-main">

--- a/frontend/src/styles/profile-popup.css
+++ b/frontend/src/styles/profile-popup.css
@@ -12,3 +12,13 @@
   border-radius: 5px;
   border: 1px solid var(--primary-color);
 }
+
+.skip-btn {
+  margin-top: 0.5rem;
+  padding: 10px 20px;
+  background-color: transparent;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 5px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- trigger profile popup after login with Clerk
- allow skipping profile setup
- style skip button

## Testing
- `npm run lint --workspace frontend`
- `npm run lint --workspace backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685988995130833191fe385b31281929