### PR TITLE
Fix sign-in redirect by handling Clerk callback routes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,8 +20,8 @@ function App() {
         <Route path="/blog" element={<BlogPage />} />
         <Route path="/community" element={<CommunityPage />} />
         <Route path="/producto" element={<ProductPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/sign-up" element={<SignUpPage />} />
+        <Route path="/login/*" element={<LoginPage />} />
+        <Route path="/sign-up/*" element={<SignUpPage />} />
         <Route path="/search" element={<SearchResults />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/contact" element={<ContactPage />} />

--- a/frontend/src/components/LoginSection.jsx
+++ b/frontend/src/components/LoginSection.jsx
@@ -12,7 +12,7 @@ export default function LoginSection() {
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>
         <div className="welcome-message">
-          <SignIn path="/login" routing="path" signUpUrl="/sign-up" afterSignInUrl="/" />
+          <SignIn path="/login/*" routing="path" signUpUrl="/sign-up" afterSignInUrl="/" />
         </div>
       </div>
     </section>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, useNavigate } from 'react-router-dom';
 import { ClerkProvider } from '@clerk/clerk-react';
 import App from './App';
 import './index.css';
 
+function ClerkProviderWithRouter({ children }) {
+  const navigate = useNavigate();
+  return (
+    <ClerkProvider
+      publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}
+      navigate={to => navigate(to)}
+    >
+      {children}
+    </ClerkProvider>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
-    <BrowserRouter>
+  <BrowserRouter>
+    <ClerkProviderWithRouter>
       <App />
-    </BrowserRouter>
-  </ClerkProvider>
+    </ClerkProviderWithRouter>
+  </BrowserRouter>
 );

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -13,7 +13,7 @@ export default function SignUpPage() {
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>
         <div className="welcome-message">
-          <SignUp path="/sign-up" routing="path" signInUrl="/login" afterSignUpUrl="/" />
+          <SignUp path="/sign-up/*" routing="path" signInUrl="/login" afterSignUpUrl="/" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add React Router integration for Clerk
- handle `/login/*` and `/sign-up/*` routes so Clerk can process callback paths

## Testing
- `npm --workspace frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68599b560b7883318cca1514ec2fd5e1