### PR TITLE
Fix Clerk path parsing error

### DIFF
--- a/frontend/src/components/LoginSection.jsx
+++ b/frontend/src/components/LoginSection.jsx
@@ -12,7 +12,7 @@ export default function LoginSection() {
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>
         <div className="welcome-message">
-          <SignIn path="/login/*" routing="path" signUpUrl="/sign-up" afterSignInUrl="/" />
+          <SignIn path="/login" routing="path" signUpUrl="/sign-up" afterSignInUrl="/" />
         </div>
       </div>
     </section>

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -13,7 +13,7 @@ export default function SignUpPage() {
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>
         <div className="welcome-message">
-          <SignUp path="/sign-up/*" routing="path" signInUrl="/login" afterSignUpUrl="/" />
+          <SignUp path="/sign-up" routing="path" signInUrl="/login" afterSignUpUrl="/" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- fix SignIn/SignUp component path strings to avoid clerk regex errors

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to parse source in ProfilePopupContext.js)*

------
https://chatgpt.com/codex/tasks/task_e_6859ac4222a08331a8a18095a8d3e56b