### PR TITLE
UI tweaks for icons, loader and community posts

### DIFF
--- a/frontend/src/components/CommunityCard.jsx
+++ b/frontend/src/components/CommunityCard.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { FaThumbsUp, FaThumbsDown } from 'react-icons/fa';
+import {
+  FaThumbsUp,
+  FaThumbsDown,
+  FaRegThumbsUp,
+  FaRegThumbsDown,
+} from 'react-icons/fa';
 
 const CommunityCard = ({ post, onLike, onDislike }) => {
   const isLiked = post.liked;
@@ -15,11 +20,19 @@ const CommunityCard = ({ post, onLike, onDislike }) => {
         <span className="community-time-posted">{post.fecha}</span>
         <div className="community-card-footer">
           <button className={`like-button ${isLiked ? 'active' : ''}`} onClick={() => onLike(post.id)}>
-            <FaThumbsUp className="img-like" />
+            {isLiked ? (
+              <FaThumbsUp className="img-like" color="green" />
+            ) : (
+              <FaRegThumbsUp className="img-like" color="green" />
+            )}
             <span className="like-count">{post.likes}</span>
           </button>
           <button className={`dislike-button ${isDisliked ? 'active' : ''}`} onClick={() => onDislike(post.id)}>
-            <FaThumbsDown className="img-dislike" />
+            {isDisliked ? (
+              <FaThumbsDown className="img-dislike" color="red" />
+            ) : (
+              <FaRegThumbsDown className="img-dislike" color="red" />
+            )}
             <span className="dislike-count">{post.dislikes}</span>
           </button>
         </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -6,7 +6,7 @@ import Loader from './Loader';
 import {
   FaHome,
   FaUsers,
-  FaBlog,
+  FaRegNewspaper,
   FaEnvelopeOpenText,
   FaUserCircle,
   FaChevronDown,
@@ -123,7 +123,7 @@ const Header = () => {
           <span>Comunidad</span>
         </Link>
         <Link to="/blog">
-          <FaBlog size={30} />
+          <FaRegNewspaper size={30} />
           <span>Blog</span>
         </Link>
         <Link to="/contact">

--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useRef } from 'react';
 import CameraModal from './CameraModal';
 import { useNavigate } from 'react-router-dom';
-import { FaSearch, FaCamera } from 'react-icons/fa';
+import { FiSearch, FiCamera } from 'react-icons/fi';
 
 const HeroSection = () => {
   const [query, setQuery] = useState('');
@@ -66,7 +66,7 @@ const HeroSection = () => {
                 className="search-button search-icon-button"
                 onClick={handleSearch}
               >
-                <FaSearch size={20} />
+                <FiSearch size={20} />
               </button>
               <input
                 type="text"
@@ -81,7 +81,7 @@ const HeroSection = () => {
                 className="search-button camera-icon-button"
                 onClick={handleCameraClick}
               >
-                <FaCamera size={20} />
+                <FiCamera size={20} />
               </button>
               <input
                 type="file"

--- a/frontend/src/components/LoginSection.jsx
+++ b/frontend/src/components/LoginSection.jsx
@@ -1,13 +1,9 @@
 import { SignIn } from '@clerk/clerk-react';
-import { FaArrowLeft } from 'react-icons/fa';
 
 export default function LoginSection() {
   return (
     <section id="login-section" className="login-container">
       <div className="login-content">
-        <button className="back-button" onClick={() => window.location.href = '/'}>
-          <FaArrowLeft />
-        </button>
         <div className="illustration">
           <img src="/img/img_login.svg" alt="Ilustración" />
         </div>

--- a/frontend/src/pages/BlogPage.jsx
+++ b/frontend/src/pages/BlogPage.jsx
@@ -3,7 +3,7 @@ import Loader from '../components/Loader';
 import axios from 'axios';
 import BlogCard from '../components/BlogCard';
 import BlogPopup from '../components/BlogPopup';
-import { FaSearch } from 'react-icons/fa';
+import { FiSearch } from 'react-icons/fi';
 
 const BlogPage = () => {
   const [posts, setPosts] = useState([]);
@@ -53,7 +53,7 @@ const BlogPage = () => {
             <p>Descubrí herramientas prácticas, consejos útiles y perspectivas actuales para transformar tu relación con la comida.</p>
             <div className="search-bar">
               <button className="search-button search-icon-button" onClick={() => handleSearch({ key: 'Enter' })}>
-                <FaSearch size={20} />
+                <FiSearch size={20} />
               </button>
               <input
                 type="text"
@@ -71,21 +71,23 @@ const BlogPage = () => {
 
       {/* LISTADO DE ARTÍCULOS */}
       <section className="sec-nutrition-lifestyle" style={{ display: popupPost ? 'none' : 'block' }}>
-        <div className="nutrition-lifestyle-inner">
-          <h3>Nutrición y Estilo de Vida</h3>
-          <p>
-            Explorá artículos cuidadosamente seleccionados sobre bienestar integral, alimentación consciente y hábitos saludables. Inspirate para hacer cambios positivos y sostenibles.
-          </p>
-          <div className="cards-row" id="cardsContainer">
-            {loading ? (
-              <Loader />
-            ) : (
-              posts.map((post, idx) => (
-                <BlogCard key={idx} post={post} onClick={handleCardClick} />
-              ))
-            )}
+        {loading ? (
+          <div className="loader">
+            <Loader />
           </div>
-        </div>
+        ) : (
+          <div className="nutrition-lifestyle-inner">
+            <h3>Nutrición y Estilo de Vida</h3>
+            <p>
+              Explorá artículos cuidadosamente seleccionados sobre bienestar integral, alimentación consciente y hábitos saludables. Inspirate para hacer cambios positivos y sostenibles.
+            </p>
+            <div className="cards-row" id="cardsContainer">
+              {posts.map((post, idx) => (
+                <BlogCard key={idx} post={post} onClick={handleCardClick} />
+              ))}
+            </div>
+          </div>
+        )}
       </section>
 
       {/* POPUP DE ARTÍCULO */}

--- a/frontend/src/pages/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage.jsx
@@ -103,27 +103,36 @@ const CommunityPage = () => {
           <div className="community-cards-container">
             {loading ? (
               <Loader />
-            ) : posts.length === 0 ? (
-              <p>No hay posts aún. ¡Sé el primero en publicar!</p>
             ) : (
-              posts.map(post => (
-                <CommunityCard
-                  key={post.id}
-                  post={post}
-                  onLike={handleLike}
-                  onDislike={handleDislike}
-                />
-              ))
+              <>
+                <div
+                  className="community-card create-post-card"
+                  onClick={() => {
+                    if (!auth.authenticated) return navigate('/login');
+                    setPopupOpen(true);
+                  }}
+                >
+                  <div className="bottom-community-card" style={{ alignItems: 'center' }}>
+                    <FaPlus size={24} />
+                    <p className="community-card-text">Crear un post</p>
+                  </div>
+                </div>
+                {posts.length === 0 ? (
+                  <p>No hay posts aún. ¡Sé el primero en publicar!</p>
+                ) : (
+                  posts.map(post => (
+                    <CommunityCard
+                      key={post.id}
+                      post={post}
+                      onLike={handleLike}
+                      onDislike={handleDislike}
+                    />
+                  ))
+                )}
+              </>
             )}
           </div>
         </div>
-
-        <button className="button-add-post" onClick={() => {
-          if (!auth.authenticated) return navigate('/login');
-          setPopupOpen(true);
-        }}>
-          <FaPlus />
-        </button>
       </section>
 
       <CommunityPopup

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -13,6 +13,11 @@ const HomePage = () => {
   const [showPopup, setShowPopup] = useState(false);
   const { isLoaded, isSignedIn } = useAuth();
 
+  const handleClose = () => {
+    localStorage.setItem('healthPopupSeen', 'true');
+    setShowPopup(false);
+  };
+
   useEffect(() => {
     if (!isLoaded || !isSignedIn) return;
 
@@ -21,7 +26,8 @@ const HomePage = () => {
         const auth = await axios.get(`${import.meta.env.VITE_API_URL}/api/auth`, { withCredentials: true });
         if (!auth.data.authenticated) return;
         const res = await axios.get(`${import.meta.env.VITE_API_URL}/api/user/me`, { withCredentials: true });
-        if (!res.data.completo) setShowPopup(true);
+        const seen = localStorage.getItem('healthPopupSeen');
+        if (!seen && !res.data.completo) setShowPopup(true);
       } catch (err) {
         console.error('Error al verificar perfil', err);
       }
@@ -39,7 +45,7 @@ const HomePage = () => {
       <Functionalities />
       {/* Sección que muestra publicaciones de la comunidad, ideal para fomentar la participación del usuario: <CommunityPosts/>*/}
       <ContactSection />
-      <ProfilePopup isOpen={showPopup} onClose={() => setShowPopup(false)} onSaved={() => setShowPopup(false)} />
+      <ProfilePopup isOpen={showPopup} onClose={handleClose} onSaved={handleClose} />
     </div>
   );
 };

--- a/frontend/src/styles/community.css
+++ b/frontend/src/styles/community.css
@@ -1,10 +1,10 @@
 /* ------------------ COMMUNITY SECTION STYLES  ------------------ */
 
-.like-button.active .img-like {
-  filter: brightness(1.5);
+.like-button .img-like {
+  color: green;
 }
-.dislike-button.active .img-dislike {
-  filter: brightness(0.5);
+.dislike-button .img-dislike {
+  color: red;
 }
 
 .community-section {
@@ -50,6 +50,17 @@
   align-items: center;
   padding-bottom: 1.5rem;
   gap: 1.2rem;
+}
+
+.create-post-card {
+  cursor: pointer;
+  justify-content: center;
+  min-height: 200px;
+}
+.create-post-card svg {
+  width: 40px;
+  height: 40px;
+  color: var(--primary-color);
 }
 
 

--- a/frontend/src/styles/hero.css
+++ b/frontend/src/styles/hero.css
@@ -90,15 +90,16 @@
   margin-top: 0.3rem;
 }
 
+
 .search-button img {
-  width: 33px;
-  height: 33px;
+  width: 24px;
+  height: 24px;
 }
 
 /* Consistent sizing for icon components */
 .search-button svg {
-  width: 33px;
-  height: 33px;
+  width: 24px;
+  height: 24px;
 }
 
 .info-buttons {


### PR DESCRIPTION
## Summary
- switch blog link to `FaRegNewspaper`
- use feather camera and search icons with smaller size
- color community like/dislike icons and switch between filled/outline
- remove back arrow from login page
- add create post card to community
- hide blog list until posts load
- only show health info popup once

## Testing
- `npm run lint --workspace frontend`
- `npm run generate --workspace backend`


------
https://chatgpt.com/codex/tasks/task_e_685a9f79522c8331ad607a6940510cfe