### PR TITLE
Fix image upload failure on posts without IMGBB key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The project uses two environment files inside the `backend` folder:
 
 The frontend keeps its own public variables in `frontend/.env`.
 Add `VITE_IMGBB_KEY` with your imgbb API key to enable image uploads for
-community posts.
+community posts. If the key is missing, posts will still be created but
+any selected images will be ignored.
 
 ## Development
 

--- a/frontend/src/pages/CommunityPage.jsx
+++ b/frontend/src/pages/CommunityPage.jsx
@@ -124,13 +124,23 @@ const CommunityPage = () => {
     try {
       let imageUrl = null;
       if (selectedImage) {
-        const formData = new FormData();
-        formData.append('image', selectedImage);
-        const imgbbRes = await axios.post(
-          `https://api.imgbb.com/1/upload?key=${import.meta.env.VITE_IMGBB_KEY}`,
-          formData
-        );
-        imageUrl = imgbbRes.data.data.url;
+        const key = import.meta.env.VITE_IMGBB_KEY;
+        if (key) {
+          const formData = new FormData();
+          formData.append('image', selectedImage);
+          try {
+            const imgbbRes = await axios.post(
+              `https://api.imgbb.com/1/upload?key=${key}`,
+              formData
+            );
+            imageUrl = imgbbRes.data.data.url;
+          } catch (err) {
+            console.error('Error al subir la imagen a imgbb:', err);
+            alert('No se pudo subir la imagen, se publicará sin ella.');
+          }
+        } else {
+          console.warn('VITE_IMGBB_KEY no definido, omitiendo subida de imagen');
+        }
       }
 
       await axios.post(


### PR DESCRIPTION
## Summary
- handle missing `VITE_IMGBB_KEY` when uploading images from Community page
- document the behaviour in README

## Testing
- `npm run lint --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_685aa5e2bba88331a648f1fd41ed8770