### PR TITLE
Fix community posts image loading and filtering

### DIFF
--- a/backend/controllers/home.controller.js
+++ b/backend/controllers/home.controller.js
@@ -441,6 +441,9 @@ registrarUsuario: async (req, res) => {
 
   obtenerPosts: async (req, res) => {
     const posts = await prisma.posts.findMany({
+      where: {
+        NOT: { id_usuario: 1 }
+      },
       orderBy: { fecha_creacion: 'desc' },
       include: {
         usuario: true,

--- a/frontend/src/components/CommunityCard.jsx
+++ b/frontend/src/components/CommunityCard.jsx
@@ -13,7 +13,11 @@ const CommunityCard = ({ post, onLike, onDislike }) => {
   return (
     <div className="community-card">
       {post.imagen_url && (
-        <img src={post.imagen_url} alt="Imagen del post" className="community-card-image" />
+        <img
+          src={post.imagen_url.startsWith('http') ? post.imagen_url : `/img/${post.imagen_url}`}
+          alt="Imagen del post"
+          className="community-card-image"
+        />
       )}
       <div className="bottom-community-card">
         <p className="community-card-text">{post.contenido}</p>

--- a/frontend/src/components/CommunityPosts.jsx
+++ b/frontend/src/components/CommunityPosts.jsx
@@ -29,7 +29,10 @@ const CommunityPosts = () => {
                   <p className="descripcion-card-blog">{post.contenido_post}</p>
                 </div>
                 <div className="contenedor-imagen-card-blog">
-                  <img src={`./public/img/${post.imagen_url}`} alt="Imagen del post" />
+                  <img
+                    src={post.imagen_url.startsWith('http') ? post.imagen_url : `/img/${post.imagen_url}`}
+                    alt="Imagen del post"
+                  />
                 </div>
               </div>
             ))


### PR DESCRIPTION
## Summary
- show community post images whether absolute or stored in /img
- filter community posts in the API so they exclude user ID 1 posts

## Testing
- `npm run -w frontend lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865e31a8cd88331b1cf219acc2cbe21