### PR TITLE
Add product comparison feature

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import SignUpPage from './pages/SignUp';
 import SearchResults from './pages/SearchResults';
 import ContactPage from './pages/ContactPage';
 import ProfilePage from './pages/ProfilePage';
+import ComparePage from './pages/ComparePage';
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
         <Route path="/sign-up/*" element={<SignUpPage />} />
         <Route path="/search" element={<SearchResults />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/compare" element={<ComparePage />} />
         <Route path="/contact" element={<ContactPage />} />
       </Routes>
       </Layout>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,3 +19,4 @@
 @import './styles/camera.css';
 @import './styles/profile-popup.css';
 @import './styles/profile-page.css';
+@import './styles/compare-page.css';

--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const mapScoreToRating = (score) => {
+  if (typeof score !== 'number') return null;
+  const min = -15;
+  const max = 40;
+  const clamped = Math.min(Math.max(score, min), max);
+  const scaled = ((max - clamped) / (max - min)) * 9 + 1;
+  return Math.round(scaled);
+};
+
+const getRatingColorClass = (rating) => {
+  if (rating >= 8) return 'green';
+  if (rating >= 6) return 'yellow';
+  if (rating >= 4) return 'orange';
+  return 'red';
+};
+
+const ComparePage = () => {
+  const [params] = useSearchParams();
+  const names = (params.get('names') || '')
+    .split(',')
+    .map(n => decodeURIComponent(n))
+    .filter(Boolean);
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (names.length === 0) return;
+    setLoading(true);
+    Promise.all(
+      names.map(n =>
+        fetch(`/api/product?query=${encodeURIComponent(n)}`)
+          .then(res => res.json())
+          .catch(() => null)
+      )
+    ).then(data => {
+      setProducts(data.filter(Boolean));
+      setLoading(false);
+    });
+  }, [names]);
+
+  if (loading) return <p className="compare-loading">Cargando...</p>;
+
+  const allKeys = Array.from(
+    new Set(products.flatMap(p => Object.keys(p)))
+  );
+
+  return (
+    <div className="compare-page">
+      <h1>Comparar Productos</h1>
+      {products.length < 2 ? (
+        <p>No se encontraron suficientes productos.</p>
+      ) : (
+        <div className="compare-table">
+          <div className="compare-header">
+            {products.map((p, i) => {
+              const rating = mapScoreToRating(p.nutriscore_score);
+              const color = rating ? getRatingColorClass(rating) : null;
+              return (
+                <div key={i} className="compare-product">
+                  <img
+                    src={p.image_url || '/img/lays-classic.svg'}
+                    alt={p.product_name}
+                  />
+                  <h3>{p.product_name}</h3>
+                  {rating && (
+                    <div
+                      className={`rating-circle rating-${color}`}
+                      title={`Calidad: ${rating}/10`}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <table>
+            <tbody>
+              {allKeys.map(key => (
+                <tr key={key}>
+                  <th>{key}</th>
+                  {products.map((p, i) => (
+                    <td key={i}>{
+                      typeof p[key] === 'object'
+                        ? JSON.stringify(p[key])
+                        : p[key] ?? 'N/A'
+                    }</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ComparePage;

--- a/frontend/src/pages/SearchResults.jsx
+++ b/frontend/src/pages/SearchResults.jsx
@@ -8,6 +8,8 @@ const SearchResults = () => {
   const query = params.get('query') || '';
   const [loading, setLoading] = useState(true);
   const [products, setProducts] = useState([]);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selected, setSelected] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -27,7 +29,24 @@ const SearchResults = () => {
   }, [query]);
 
   const handleClick = (name) => {
-    navigate(`/producto?query=${encodeURIComponent(name)}`);
+    if (selectionMode) {
+      setSelected(prev =>
+        prev.includes(name) ? prev.filter(n => n !== name) : [...prev, name]
+      );
+    } else {
+      navigate(`/producto?query=${encodeURIComponent(name)}`);
+    }
+  };
+
+  const toggleSelection = () => {
+    if (selectionMode) setSelected([]);
+    setSelectionMode(!selectionMode);
+  };
+
+  const handleCompare = () => {
+    if (selected.length < 2) return;
+    const names = selected.map(n => encodeURIComponent(n)).join(',');
+    navigate(`/compare?names=${names}`);
   };
 
   const skeletons = Array.from({ length: 6 });
@@ -36,6 +55,9 @@ const SearchResults = () => {
     <div className="search-results-page">
       <header className="results-header">
         <h2>Resultados para &quot;{query}&quot;</h2>
+        <button className="selection-toggle" onClick={toggleSelection}>
+          {selectionMode ? 'Cancelar' : 'Seleccionar'}
+        </button>
       </header>
 
       {loading ? (
@@ -53,16 +75,31 @@ const SearchResults = () => {
         <p className="no-results">No se encontraron productos.</p>
       ) : (
         <div className="cards-container">
-          {products.map((p, i) => (
-            <div
-              key={i}
-              className="product-card"
-              onClick={() => handleClick(p.name)}
-            >
-              <LazyImage src={p.image} alt={p.name} className="card-image" />
-              <h3 className="card-title">{p.name}</h3>
-            </div>
-          ))}
+          {products.map((p, i) => {
+            const isSelected = selected.includes(p.name);
+            return (
+              <div
+                key={i}
+                className={`product-card${isSelected ? ' selected' : ''}`}
+                onClick={() => handleClick(p.name)}
+              >
+                <LazyImage src={p.image} alt={p.name} className="card-image" />
+                <h3 className="card-title">{p.name}</h3>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {selectionMode && (
+        <div className="compare-bar">
+          <button
+            className="compare-button"
+            disabled={selected.length < 2}
+            onClick={handleCompare}
+          >
+            Comparar ({selected.length})
+          </button>
         </div>
       )}
     </div>

--- a/frontend/src/styles/compare-page.css
+++ b/frontend/src/styles/compare-page.css
@@ -1,0 +1,52 @@
+/* ----------- COMPARE PAGE ----------- */
+.compare-page {
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.compare-header {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.compare-product {
+  text-align: center;
+}
+
+.compare-product img {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.rating-circle {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  margin: 0.5rem auto;
+}
+
+.rating-red { background-color: var(--error-color); }
+.rating-green { background-color: var(--success-color); }
+.rating-yellow { background-color: var(--warning-color); }
+.rating-orange { background-color: #ff8c00; }
+
+.compare-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.compare-table th, .compare-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.compare-loading {
+  text-align: center;
+}

--- a/frontend/src/styles/search-results.css
+++ b/frontend/src/styles/search-results.css
@@ -42,6 +42,7 @@
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   width: 100%;
   max-width: 280px;
+  position: relative;
 }
 
 .search-results-page .product-card:hover {
@@ -329,4 +330,44 @@
     width: 100%;
     text-align: center;
   }
+}
+
+/* Selection mode */
+.selection-toggle {
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  color: #fff;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.product-card.selected {
+  box-shadow: 0 0 0 3px var(--primary-color);
+}
+
+.compare-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--secondary3-color);
+  border-top: 1px solid var(--secondary6-color);
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.compare-button {
+  background-color: var(--primary-color);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.compare-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- enable selection mode on search results
- add bottom bar with compare button
- create product comparison page that pulls data from the API
- style comparison table and selection UI
- register new route

## Testing
- `npm run lint --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_6870f4c15a7c8331ab166556d385a84c