### PR TITLE
Fix duplicate product fetch on compare page

### DIFF
--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -19,10 +19,16 @@ const getRatingColorClass = (rating) => {
 
 const ComparePage = () => {
   const [params] = useSearchParams();
-  const names = (params.get('names') || '')
-    .split(',')
-    .map(n => decodeURIComponent(n))
-    .filter(Boolean);
+  const namesQuery = params.get('names') || '';
+
+  const names = React.useMemo(
+    () =>
+      namesQuery
+        .split(',')
+        .map(n => decodeURIComponent(n))
+        .filter(Boolean),
+    [namesQuery]
+  );
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
 


### PR DESCRIPTION
## Summary
- use `useMemo` to stabilize `names` array on compare page

## Testing
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_6870f9d8e2608331be1a2f15e29447e8