### PR TITLE
Fix prisma CLI usage across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ npm run dev
 This will run the backend server and the Vite frontend concurrently.
 
 Run `npm run lint` to check the frontend code with ESLint.
+
+## Prisma
+
+Use Prisma to interact with the database. The CLI looks for the schema at
+`backend/prisma/schema.prisma`, so you can run commands from the repository root
+or inside the `backend` folder.
+
+Introspect the existing database with:
+
+```bash
+npx prisma db pull
+```
+
+Ensure that `backend/.env.secrets` defines both `DATABASE_URL` and
+`DIRECT_URL` so Prisma can connect correctly.

--- a/backend/.env.secrets.example
+++ b/backend/.env.secrets.example
@@ -1,6 +1,7 @@
 MAIL_USER=your_email@gmail.com
 MAIL_PASS=your_password
 DATABASE_URL=your_database_url
+DIRECT_URL=your_direct_database_url
 CLERK_SECRET_KEY=your_clerk_secret_key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/google-credentials.json

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   },
   "devDependencies": {
     "concurrently": "^9.2.0"
+  },
+  "prisma": {
+    "schema": "backend/prisma/schema.prisma"
   }
 }


### PR DESCRIPTION
## Summary
- update Prisma schema path in package.json
- document Prisma commands and required secrets
- add DIRECT_URL example entry

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68777a8106048331a5fdbd7818bc6cd4