### PR TITLE
feat: create modern product comparison layout

### DIFF
--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import {
+  FiZap,
+  FiDroplet,
+  FiSlash,
+  FiGrid,
+  FiPieChart,
+  FiFeather,
+  FiShield,
+  FiTarget,
+  FiLayers,
+  FiStar
+} from 'react-icons/fi';
 
 const mapScoreToRating = (score) => {
   if (typeof score !== 'number') return null;
@@ -42,7 +54,7 @@ const ComparePage = () => {
           .catch(() => null)
       )
     ).then(data => {
-      setProducts(data.filter(Boolean));
+      setProducts(data.filter(Boolean).slice(0, 3));
       setLoading(false);
     });
   }, [names]);
@@ -50,16 +62,16 @@ const ComparePage = () => {
   if (loading) return <p className="compare-loading">Cargando...</p>;
 
   const FIELDS = [
-    { key: 'energy-kcal_100g', label: 'Energía (kcal)', path: ['nutriments', 'energy-kcal_100g'] },
-    { key: 'fat_100g', label: 'Grasas (g)', path: ['nutriments', 'fat_100g'] },
-    { key: 'saturated-fat_100g', label: 'Grasas Saturadas (g)', path: ['nutriments', 'saturated-fat_100g'] },
-    { key: 'carbohydrates_100g', label: 'Carbohidratos (g)', path: ['nutriments', 'carbohydrates_100g'] },
-    { key: 'sugars_100g', label: 'Azúcares (g)', path: ['nutriments', 'sugars_100g'] },
-    { key: 'fiber_100g', label: 'Fibra (g)', path: ['nutriments', 'fiber_100g'] },
-    { key: 'proteins_100g', label: 'Proteínas (g)', path: ['nutriments', 'proteins_100g'] },
-    { key: 'salt_100g', label: 'Sal (g)', path: ['nutriments', 'salt_100g'] },
-    { key: 'nova_group', label: 'Grupo NOVA', path: ['nova_group'] },
-    { key: 'nutriscore_score', label: 'Calidad (1-10)', path: ['nutriscore_score'], transform: mapScoreToRating }
+    { key: 'energy-kcal_100g', label: 'Energía (kcal)', icon: FiZap, path: ['nutriments', 'energy-kcal_100g'] },
+    { key: 'fat_100g', label: 'Grasas (g)', icon: FiDroplet, path: ['nutriments', 'fat_100g'] },
+    { key: 'saturated-fat_100g', label: 'Grasas Saturadas (g)', icon: FiSlash, path: ['nutriments', 'saturated-fat_100g'] },
+    { key: 'carbohydrates_100g', label: 'Carbohidratos (g)', icon: FiGrid, path: ['nutriments', 'carbohydrates_100g'] },
+    { key: 'sugars_100g', label: 'Azúcares (g)', icon: FiPieChart, path: ['nutriments', 'sugars_100g'] },
+    { key: 'fiber_100g', label: 'Fibra (g)', icon: FiFeather, path: ['nutriments', 'fiber_100g'] },
+    { key: 'proteins_100g', label: 'Proteínas (g)', icon: FiShield, path: ['nutriments', 'proteins_100g'] },
+    { key: 'salt_100g', label: 'Sal (g)', icon: FiTarget, path: ['nutriments', 'salt_100g'] },
+    { key: 'nova_group', label: 'Grupo NOVA', icon: FiLayers, path: ['nova_group'] },
+    { key: 'nutriscore_score', label: 'Calidad (1-10)', icon: FiStar, path: ['nutriscore_score'], transform: mapScoreToRating }
   ];
 
   const getValue = (obj, path) =>
@@ -75,13 +87,13 @@ const ComparePage = () => {
       {products.length < 2 ? (
         <p>No se encontraron suficientes productos.</p>
       ) : (
-        <div className="compare-table">
-          <div className="compare-header">
-            {products.map((p, i) => {
-              const rating = mapScoreToRating(p.nutriscore_score);
-              const color = rating ? getRatingColorClass(rating) : null;
-              return (
-                <div key={i} className="compare-product">
+        <div className="compare-grid">
+          {products.map((p, i) => {
+            const rating = mapScoreToRating(p.nutriscore_score);
+            const color = rating ? getRatingColorClass(rating) : null;
+            return (
+              <div key={i} className="compare-column">
+                <div className="product-header">
                   <img
                     src={p.image_url || '/img/lays-classic.svg'}
                     alt={p.product_name}
@@ -94,23 +106,25 @@ const ComparePage = () => {
                     />
                   )}
                 </div>
-              );
-            })}
-          </div>
-          <table>
-            <tbody>
-              {availableFields.map(field => (
-                <tr key={field.key}>
-                  <th>{field.label}</th>
-                  {products.map((p, i) => {
+                <ul className="feature-list">
+                  {availableFields.map(field => {
                     let val = getValue(p, field.path);
                     if (field.transform && val != null) val = field.transform(val);
-                    return <td key={i}>{val != null ? val : 'Sin datos'}</td>;
+                    const Icon = field.icon;
+                    return (
+                      <li key={field.key} className="feature-item">
+                        <Icon className="feature-icon" />
+                        <div className="feature-text">
+                          <span className="feature-label">{field.label}</span>
+                          <span className="feature-value">{val != null ? val : 'Sin datos'}</span>
+                        </div>
+                      </li>
+                    );
                   })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                </ul>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/styles/compare-page.css
+++ b/frontend/src/styles/compare-page.css
@@ -6,22 +6,34 @@
   padding: 2rem 1rem;
 }
 
-.compare-header {
+.compare-grid {
   display: flex;
   gap: 2rem;
   justify-content: center;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
 }
 
-.compare-product {
+.compare-column {
+  flex: 1 1 300px;
+  max-width: 320px;
+  background-color: var(--whiteback-color);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.product-header {
   text-align: center;
 }
 
-.compare-product img {
+.product-header img {
   width: 150px;
   height: 150px;
   object-fit: cover;
-  border-radius: 10px;
+  border-radius: 12px;
 }
 
 .rating-circle {
@@ -36,20 +48,39 @@
 .rating-yellow { background-color: var(--warning-color); }
 .rating-orange { background-color: #ff8c00; }
 
-.compare-table {
-  overflow-x: auto;
+.feature-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.compare-table table {
-  width: 100%;
-  min-width: 600px;
-  border-collapse: collapse;
+.feature-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
 }
 
-.compare-table th, .compare-table td {
-  border: 1px solid #ddd;
-  padding: 0.5rem;
-  text-align: center;
+.feature-icon {
+  width: 24px;
+  height: 24px;
+  color: var(--secondary2-color);
+  flex-shrink: 0;
+}
+
+.feature-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.feature-label {
+  font-size: 0.75rem;
+  color: var(--secondary2-color);
+}
+
+.feature-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--secondary1-color);
 }
 
 .compare-loading {
@@ -57,17 +88,14 @@
 }
 
 @media (max-width: 768px) {
-  .compare-header {
+  .compare-grid {
     flex-direction: column;
     align-items: center;
   }
 
-  .compare-product img {
+  .product-header img {
     width: 120px;
     height: 120px;
   }
-
-  .compare-table table {
-    font-size: 0.9rem;
-  }
 }
+


### PR DESCRIPTION
## Summary
- redesign product comparison page to use responsive columns with icon-based features
- style comparison component with minimalist, card-like layout and neutral palette

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890c8b8184c8331b454a5266bebb172