### PR TITLE
feat: modernize product comparison cards

### DIFF
--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -9,8 +9,7 @@ import {
   FiFeather,
   FiShield,
   FiTarget,
-  FiLayers,
-  FiStar
+  FiLayers
 } from 'react-icons/fi';
 
 const mapScoreToRating = (score) => {
@@ -70,16 +69,11 @@ const ComparePage = () => {
     { key: 'fiber_100g', label: 'Fibra (g)', icon: FiFeather, path: ['nutriments', 'fiber_100g'] },
     { key: 'proteins_100g', label: 'Proteínas (g)', icon: FiShield, path: ['nutriments', 'proteins_100g'] },
     { key: 'salt_100g', label: 'Sal (g)', icon: FiTarget, path: ['nutriments', 'salt_100g'] },
-    { key: 'nova_group', label: 'Grupo NOVA', icon: FiLayers, path: ['nova_group'] },
-    { key: 'nutriscore_score', label: 'Calidad (1-10)', icon: FiStar, path: ['nutriscore_score'], transform: mapScoreToRating }
+    { key: 'nova_group', label: 'Grupo NOVA', icon: FiLayers, path: ['nova_group'] }
   ];
 
   const getValue = (obj, path) =>
     path.reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj);
-
-  const availableFields = FIELDS.filter(field =>
-    products.some(p => getValue(p, field.path) !== undefined && getValue(p, field.path) !== null)
-  );
 
   return (
     <div className="compare-page">
@@ -94,29 +88,35 @@ const ComparePage = () => {
             return (
               <div key={i} className="compare-column">
                 <div className="product-header">
+                  <div className="quality-wrapper">
+                    <div
+                      className={`quality-circle ${rating ? `filled rating-${color}` : 'empty'}`}
+                      title={rating ? `Calidad: ${rating}/10` : 'Calidad: Sin datos'}
+                    />
+                    <span className="quality-text">
+                      {rating ? `Calidad: ${rating}/10` : 'Calidad: Sin datos'}
+                    </span>
+                  </div>
                   <img
                     src={p.image_url || '/img/lays-classic.svg'}
                     alt={p.product_name}
                   />
                   <h3>{p.product_name}</h3>
-                  {rating && (
-                    <div
-                      className={`rating-circle rating-${color}`}
-                      title={`Calidad: ${rating}/10`}
-                    />
-                  )}
                 </div>
                 <ul className="feature-list">
-                  {availableFields.map(field => {
+                  {FIELDS.map(field => {
                     let val = getValue(p, field.path);
                     if (field.transform && val != null) val = field.transform(val);
                     const Icon = field.icon;
+                    const hasData = val != null;
                     return (
                       <li key={field.key} className="feature-item">
                         <Icon className="feature-icon" />
                         <div className="feature-text">
                           <span className="feature-label">{field.label}</span>
-                          <span className="feature-value">{val != null ? val : 'Sin datos'}</span>
+                          <span className={`feature-value${hasData ? '' : ' no-data'}`}>
+                            {hasData ? val : 'Sin datos'}
+                          </span>
                         </div>
                       </li>
                     );

--- a/frontend/src/styles/compare-page.css
+++ b/frontend/src/styles/compare-page.css
@@ -13,13 +13,12 @@
   flex-wrap: wrap;
 }
 
+
 .compare-column {
   flex: 1 1 300px;
   max-width: 320px;
-  background-color: var(--whiteback-color);
   border-radius: 20px;
   padding: 1.5rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -36,11 +35,45 @@
   border-radius: 12px;
 }
 
-.rating-circle {
-  width: 30px;
-  height: 30px;
+.product-header h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  max-height: 3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-top: 0.5rem;
+}
+
+.quality-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.quality-circle {
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  margin: 0.5rem auto;
+  border: 2px solid var(--secondary2-color);
+}
+
+.quality-circle.filled {
+  border: none;
+}
+
+.quality-circle.empty {
+  background: transparent;
+}
+
+.quality-text {
+  font-size: 1.5rem;
 }
 
 .rating-red { background-color: var(--error-color); }
@@ -61,8 +94,7 @@
 }
 
 .feature-icon {
-  width: 24px;
-  height: 24px;
+  font-size: 1.5rem;
   color: var(--secondary2-color);
   flex-shrink: 0;
 }
@@ -73,14 +105,21 @@
 }
 
 .feature-label {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: var(--secondary2-color);
+  font-weight: 600;
 }
 
 .feature-value {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: 1.125rem;
+  font-weight: 700;
   color: var(--secondary1-color);
+}
+
+.feature-value.no-data {
+  font-weight: 400;
+  color: var(--secondary2-color);
+  font-style: italic;
 }
 
 .compare-loading {


### PR DESCRIPTION
## Summary
- redesign comparison cards with transparent backgrounds and responsive typography
- add leading quality indicator with filled or outlined circle
- show 'Sin datos' placeholders to keep column structure

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890ccb37e1883318bfef02d2acb36e8