### PR TITLE
chore: secure supabase credentials

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -5,3 +5,4 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3Vud
 VITE_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
 OPENFOODFACTS_API_URL=https://world.openfoodfacts.org/api/v2/search
+DATABASE_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@aws-0-us-east-2.pooler.supabase.com:6543/postgres

--- a/backend/.env.secrets.example
+++ b/backend/.env.secrets.example
@@ -1,6 +1,7 @@
 MAIL_USER=your_email@gmail.com
 MAIL_PASS=your_password
-DATABASE_URL=your_database_url
+SUPABASE_DB_USER=your_db_username
+SUPABASE_DB_PASSWORD=your_db_password
 CLERK_SECRET_KEY=your_clerk_secret_key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/google-credentials.json

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 # Keep environment variables out of version control
+.env.secrets

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "prestart": "prisma generate",
     "start": "node app.js",
     "server": "node app.js",
-    "generate": "prisma generate"
+    "generate": "prisma generate",
+    "db:pull": "dotenv -e .env.secrets -e .env -- prisma db pull"
   },
   "keywords": [],
   "author": "",
@@ -25,7 +26,8 @@
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
-    "prisma": "^6.6.0"
+    "prisma": "^6.6.0",
+    "dotenv-cli": "^7.4.4"
   },
   "description": ""
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "nodemailer": "^6.9.12"
       },
       "devDependencies": {
+        "dotenv-cli": "^7.4.4",
         "prisma": "^6.6.0"
       }
     },
@@ -3008,6 +3009,32 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.4.4.tgz",
+      "integrity": "sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dunder-proto": {


### PR DESCRIPTION
## Summary
- route Supabase database URL through environment variables to keep credentials out of version control
- document required Supabase secrets in `.env.secrets.example`
- add `db:pull` helper script with dotenv-cli

## Testing
- `npm run db:pull --workspace backend` *(fails: Can't reach database server at `aws-0-us-east-2.pooler.supabase.com:6543`)*
- `npm test --workspace backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e45a3874833192da99f7d5d37cfb