### PR TITLE
feat: use ipv4 supabase host

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,15 @@ Introspect the existing database with:
 npm run db:pull
 ```
 
-The script loads `.env.secrets` before `.env` so Prisma receives a direct
-connection string like:
+The script loads `.env.secrets` before `.env` so Prisma receives a connection
+string like:
 
 ```
-postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres?sslmode=require
+postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require&pgbouncer=true
 ```
 
-Edit `backend/.env.secrets` to provide your Supabase user and password.
+`SUPABASE_DB_HOST` defaults to Supabase's IPv4 connection pool
+(`aws-0-us-east-1.pooler.supabase.com`), which avoids IPv6-only hosts that can
+cause P1001 errors on machines without IPv6 connectivity. Adjust the host to
+match your project's region if needed. Edit `backend/.env.secrets` to provide
+your Supabase user and password.

--- a/backend/.env
+++ b/backend/.env
@@ -5,4 +5,5 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3Vud
 VITE_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
 OPENFOODFACTS_API_URL=https://world.openfoodfacts.org/api/v2/search
-DATABASE_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres?sslmode=require
+SUPABASE_DB_HOST=aws-0-us-east-1.pooler.supabase.com
+DATABASE_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require&pgbouncer=true


### PR DESCRIPTION
## Summary
- avoid IPv6-only Supabase host by defaulting to IPv4 pooler
- document new `SUPABASE_DB_HOST` and pooled connection string in README

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895fa44b0b083318b20160559effe43