### PR TITLE
Configure Prisma to use Supabase connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ The script loads `.env.secrets` before `.env` so Prisma receives a connection
 string like:
 
 ```
-postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require&pgbouncer=true
+postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:6543/postgres?pgbouncer=true
 ```
 
 `SUPABASE_DB_HOST` defaults to Supabase's IPv4 connection pool
-(`aws-0-us-east-1.pooler.supabase.com`), which avoids IPv6-only hosts that can
+(`aws-0-us-east-2.pooler.supabase.com`), which avoids IPv6-only hosts that can
 cause P1001 errors on machines without IPv6 connectivity. Adjust the host to
 match your project's region if needed. Edit `backend/.env.secrets` to provide
 your Supabase user and password.

--- a/backend/.env
+++ b/backend/.env
@@ -5,5 +5,9 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3Vud
 VITE_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
 OPENFOODFACTS_API_URL=https://world.openfoodfacts.org/api/v2/search
-SUPABASE_DB_HOST=aws-0-us-east-1.pooler.supabase.com
-DATABASE_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require&pgbouncer=true
+SUPABASE_DB_HOST=aws-0-us-east-2.pooler.supabase.com
+# Connect to Supabase via connection pooling
+DATABASE_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:6543/postgres?pgbouncer=true
+
+# Direct connection to the database. Used for migrations
+DIRECT_URL=postgresql://${SUPABASE_DB_USER}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres

--- a/backend/.env.secrets.example
+++ b/backend/.env.secrets.example
@@ -1,6 +1,6 @@
 MAIL_USER=your_email@gmail.com
 MAIL_PASS=your_password
-SUPABASE_DB_USER=postgres
+SUPABASE_DB_USER=postgres.cuphajddgbzgnomwsupa
 SUPABASE_DB_PASSWORD=your_db_password
 CLERK_SECRET_KEY=your_clerk_secret_key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -4,7 +4,8 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Actividades {


### PR DESCRIPTION
## Summary
- add direct connection URL support in Prisma schema
- document Supabase connection pooling in README and sample env files
- update environment defaults to Supabase IPv4 pool

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run db:pull --workspace backend` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6896116d8fac8331a511df6581d372b4