### PR TITLE
feat: add loader for mobile camera search

### DIFF
--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -1,12 +1,14 @@
 // src/components/HeroSection.jsx
 import React, { useState, useRef } from 'react';
 import CameraModal from './CameraModal';
+import Loader from './Loader';
 import { useNavigate } from 'react-router-dom';
 import { FiSearch, FiCamera } from 'react-icons/fi';
 
 const HeroSection = () => {
   const [query, setQuery] = useState('');
   const [showCamera, setShowCamera] = useState(false);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const fileInputRef = useRef(null);
   const isMobile = /Mobi|Android/i.test(navigator.userAgent);
@@ -36,6 +38,7 @@ const HeroSection = () => {
     const formData = new FormData();
     formData.append('image', file, 'capture.jpg');
     try {
+      setLoading(true);
       const res = await fetch('http://localhost:3000/api/camera/upload', {
         method: 'POST',
         body: formData,
@@ -48,7 +51,11 @@ const HeroSection = () => {
     } catch (err) {
       console.error('Camera search error', err);
     } finally {
+      setLoading(false);
       setShowCamera(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     }
   };
 
@@ -106,6 +113,11 @@ const HeroSection = () => {
           <div className="search-hint">Presioná Enter o la lupa para buscar</div>
         </div>
       </div>
+      {loading && (
+        <div className="page-loader">
+          <Loader />
+        </div>
+      )}
     </section>
   );
 };

--- a/frontend/src/styles/camera.css
+++ b/frontend/src/styles/camera.css
@@ -24,3 +24,17 @@
   align-items: center;
   background-color: rgba(255, 255, 255, 0.7);
 }
+
+.page-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.7);
+  z-index: 1000;
+}
+


### PR DESCRIPTION
## Summary
- show full-page loader while camera search processes
- add global page loader styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68961a18eae48331ba476b158d3c9864