### PR TITLE
feat: add backend test route

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -51,6 +51,22 @@ app.use(session({
 app.use('/api', homeRoutes);
 app.use('/api/camera', cameraRoutes);
 
+// 🧪 Ruta de prueba para inspeccionar el estado del backend
+app.get('/api/test', (req, res) => {
+  const info = {
+    message: 'Backend operativo',
+    env: app.get('env'),
+    port: PORT,
+    cors: allowedOrigins,
+    sessionID: req.sessionID,
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  };
+
+  console.log('Información de prueba:', info);
+  res.json(info);
+});
+
 // 🏠 Ruta base
 app.get('/', (req, res) => {
   res.send('API activa');


### PR DESCRIPTION
## Summary
- add `/api/test` endpoint to inspect backend status and configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `node backend/app.js` & `curl -s http://localhost:3000/api/test`


------
https://chatgpt.com/codex/tasks/task_e_6899d40ef9cc83318faec46cc109c9da