### PR TITLE
Prepare backend for Vercel serverless deployment

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+const app = require('../backend/app');
+module.exports = app;

--- a/backend/app.js
+++ b/backend/app.js
@@ -49,7 +49,11 @@ app.get('/', (req, res) => {
   res.send('API activa');
 });
 
-// 🚀 Iniciar servidor
-app.listen(PORT);
+// 🚀 Iniciar servidor solo si se ejecuta directamente
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Servidor escuchando en el puerto ${PORT}`);
+  });
+}
 
-
+module.exports = app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/index.js", "use": "@vercel/node" }],
+  "routes": [{ "src": "/(.*)", "dest": "/api/index.js" }]
+}


### PR DESCRIPTION
## Summary
- export Express app so Vercel can use it as a serverless function
- add `/api` handler and `vercel.json` rewrites to route requests

## Testing
- `npm test --workspace backend` *(fails: Missing script "test")*
- `npm start --workspace backend`


------
https://chatgpt.com/codex/tasks/task_e_689a2602b82c833183baceef3e61cd31