### PR TITLE
Improve client responsiveness with cached data and loaders

### DIFF
--- a/frontend/src/pages/ComparePage.jsx
+++ b/frontend/src/pages/ComparePage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import Loader from '../components/Loader';
 import {
   FaBolt,
   FaTint,
@@ -47,7 +48,7 @@ const ComparePage = () => {
     });
   }, [names]);
 
-  if (loading) return <p className="compare-loading">Cargando...</p>;
+    if (loading) return <Loader />;
 
   const FIELDS = [
     {

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import Loader from '../components/Loader';
 
 const ProfilePage = () => {
   const [patologias, setPatologias] = useState([]);
@@ -75,7 +76,7 @@ const ProfilePage = () => {
     }
   };
 
-  if (loading) return <p>Cargando...</p>;
+    if (loading) return <Loader />;
 
   return (
     <section className="profile-page">

--- a/frontend/src/styles/search-results.css
+++ b/frontend/src/styles/search-results.css
@@ -112,6 +112,15 @@
   animation: skeleton-loading 1.2s infinite ease-in-out;
 }
 
+.search-results-page .text-skeleton {
+  width: 80%;
+  height: 1.2rem;
+  background-color: var(--secondary6-color);
+  margin: 0.75rem auto;
+  border-radius: 4px;
+  animation: skeleton-loading 1.2s infinite ease-in-out;
+}
+
 @keyframes skeleton-loading {
   0% {
     opacity: 0.5;


### PR DESCRIPTION
## Summary
- Cache search results in sessionStorage to avoid refetching when navigating back
- Persist auth data in sessionStorage so the header renders immediately without loader
- Replace text placeholders with skeleton/loader components and add text skeleton styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a31f7937483319de5428bbf3aaf0c