### PR TITLE
Fix mobile navbar visibility

### DIFF
--- a/frontend/src/styles/search-results.css
+++ b/frontend/src/styles/search-results.css
@@ -316,7 +316,8 @@
   .nav-links {
     position: fixed;
     top: 0;
-    right: -100%;
+    right: 0;
+    transform: translateX(100%);
     width: 70%;
     max-width: 300px;
     height: 100vh;
@@ -325,12 +326,12 @@
     gap: 30px;
     padding: 80px 20px;
     box-shadow: -5px 0 15px rgba(0, 0, 0, 0.1);
-    transition: right 0.3s ease;
+    transition: transform 0.3s ease;
     z-index: 1000;
   }
-  
+
   .nav-links.active {
-    right: 0;
+    transform: translateX(0);
   }
   
   .nav-links a {


### PR DESCRIPTION
## Summary
- Hide mobile nav menu completely off-screen when collapsed
- Slide in navbar via transform from the right on activation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a32d822ec83319889687bdc3f2476