### PR TITLE
feat: enable dev mode search timing alerts

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -18,6 +18,7 @@ const Header = () => {
   const [loading, setLoading] = useState(true);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [devMode, setDevMode] = useState(() => localStorage.getItem('devMode') === 'true');
   const dropdownRef = useRef(null);
   const navigate = useNavigate();
   
@@ -76,6 +77,11 @@ const Header = () => {
   const toggleDropdown = () => setDropdownOpen(!dropdownOpen);
   const toggleMenu = () => setMenuOpen(prev => !prev);
   const closeMenu = () => setMenuOpen(false);
+  const toggleDevMode = () => {
+    const value = !devMode;
+    setDevMode(value);
+    localStorage.setItem('devMode', value);
+  };
 
   return (
     <header>
@@ -139,6 +145,13 @@ const Header = () => {
           </div>
         )}
       </nav>
+      <button
+        type="button"
+        className="dev-toggle"
+        onClick={toggleDevMode}
+      >
+        {devMode ? 'Modo Dev: ON' : 'Modo Dev: OFF'}
+      </button>
       <div className={`overlay ${menuOpen ? 'active' : ''}`} onClick={closeMenu}></div>
     </header>
   );

--- a/frontend/src/pages/SearchResults.jsx
+++ b/frontend/src/pages/SearchResults.jsx
@@ -25,6 +25,7 @@ const SearchResults = () => {
     // available (e.g., misconfigured builds or previews).
     const apiBase = import.meta.env.VITE_API_URL || 'https://zeta-v2-backend.vercel.app';
     const start = performance.now();
+    const isDev = import.meta.env.DEV || localStorage.getItem('devMode') === 'true';
     fetch(`${apiBase}/api/SearchProducts?query=${encodeURIComponent(query)}`)
       .then(res => res.json())
       .then(data => {
@@ -32,7 +33,7 @@ const SearchResults = () => {
           setProducts(data.products);
           const elapsed = (performance.now() - start).toFixed(2);
           const source = data.source === 'cache' ? 'la cache' : 'OpenFoodFacts';
-          if (import.meta.env.DEV) {
+          if (isDev) {
             setAlertMessage(`Resultados obtenidos de ${source} en ${elapsed} ms`);
           }
         } else {

--- a/frontend/src/styles/header.css
+++ b/frontend/src/styles/header.css
@@ -44,6 +44,16 @@ header {
   height: 30px;
 }
 
+.dev-toggle {
+  margin-left: 1rem;
+  background: none;
+  border: 1px solid var(--secondary2-color);
+  color: var(--secondary2-color);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .login-button, .icon-group {
   display: flex;
   align-items: center;
@@ -217,6 +227,11 @@ span.button-text{
   .nav-links a {
     width: 100%;
     padding: 1rem 0;
+  }
+
+  .dev-toggle {
+    margin-top: 1rem;
+    margin-left: 0;
   }
 
   .login-button,


### PR DESCRIPTION
## Summary
- add header toggle to persist dev mode flag in localStorage
- show search time alerts when dev mode active even in production
- style dev mode toggle button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a467a2fb6c8331a708f4bddc1ab12e